### PR TITLE
feat: Refactor elvdoc API to use core package functions

### DIFF
--- a/elvdoc.go
+++ b/elvdoc.go
@@ -11,56 +11,43 @@
 package elvdoc
 
 import (
-	"io"
-	"os"
+	"path/filepath"
+
+	"github.com/elvoiz/elvdoc/core"
 )
 
-// Document represents the structured data of an .elv file.
-type Document struct {
-	// TODO: Define fields according to .elv file structure
-	// Example:
-	// ID      string
-	// Content string
+// ReadElvDoc reads all elvdoc files from a directory and returns their content as strings.
+// It expects the directory to contain template.html, style.css, function.js, and config.yaml.
+func ReadElvDoc(dir string) (templateHTML, styleCSS, functionJS, configYAML string, err error) {
+	return core.ReadElvDocFiles(dir)
 }
 
-// Reader is the interface for reading .elv files.
-type Reader interface {
-	Read(r io.Reader) (*Document, error)
-}
-
-// Writer is the interface for writing .elv files.
-type Writer interface {
-	Write(w io.Writer, doc *Document) error
-}
-
-// ReadFile reads an .elv file from the given path and returns a Document.
-func ReadFile(path string) (*Document, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
+// WriteElvDoc writes the provided elvdoc files to a .elv (tar.gz) archive.
+// The outputPath should end with .elv or .tar.gz.
+func WriteElvDoc(outputPath, templateHTML, styleCSS, functionJS, configYAML string) error {
+	// Accept .elv as extension, but store as .tar.gz
+	ext := filepath.Ext(outputPath)
+	if ext == ".elv" {
+		outputPath = outputPath + ".tar.gz"
 	}
-	defer f.Close()
-	return Read(f)
+	return core.CreateElvArchive(outputPath, templateHTML, styleCSS, functionJS, configYAML)
 }
 
-// WriteFile writes a Document to an .elv file at the given path.
-func WriteFile(path string, doc *Document) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
+// WriteElvDocFromDir writes a .elv (tar.gz) archive from a directory containing elvdoc files.
+func WriteElvDocFromDir(outputPath, sourceDir string) error {
+	ext := filepath.Ext(outputPath)
+	if ext == ".elv" {
+		outputPath = outputPath + ".tar.gz"
 	}
-	defer f.Close()
-	return Write(f, doc)
+	return core.CreateElvArchiveFromDir(outputPath, sourceDir)
 }
 
-// Read parses an .elv file from an io.Reader.
-func Read(r io.Reader) (*Document, error) {
-	// TODO: Implement parsing logic
-	return &Document{}, nil
+// IsValidElvDocArchive checks if a file is a valid elvdoc archive.
+func IsValidElvDocArchive(path string) bool {
+	return core.IsValidElvArchive(path)
 }
 
-// Write serializes a Document to an io.Writer as an .elv file.
-func Write(w io.Writer, doc *Document) error {
-	// TODO: Implement serialization logic
-	return nil
-}
+// Example usage:
+//  template, css, js, yaml, err := elvdoc.ReadElvDoc("format/elvdoc")
+//  err = elvdoc.WriteElvDoc("output.elv", template, css, js, yaml)
+//  valid := elvdoc.IsValidElvDocArchive("output.elv.tar.gz")


### PR DESCRIPTION
Replaces previous Document-based API with higher-level functions that read and write elvdoc files using the core package. Removes unused types and interfaces, and adds utility functions for reading, writing, and validating elvdoc archives. Updates file extension handling and provides example usage.